### PR TITLE
Replace reference to deprecated script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Start the Fabric and create a Composer profile using the following commands:
 ```bash
 ./downloadFabric.sh
 ./startFabric.sh
-./createComposerProfile.sh
+./createPeerAdminCard.sh
 ```  
 
 No need to do it now; however as an fyi - you can stop and tear down Fabric using:


### PR DESCRIPTION
Running `./createComposerProfile.sh` gives the following warning:

```
NOTE: createComposerProfile is deprecated from v0.15.0 Please use createPeerAdminCard.sh
```

This PR replaces the example invocation of `createComposerProfile.sh` with `createPeerAdminCard.sh` as suggested.