### PR TITLE
Fixed last part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ Answer the questions posed at startup. These allow the composer-rest-server to c
 * Select `never use namespaces` when asked whether to use namespaces in the generated API.
 * Select `No` when asked whether to secure the generated API.
 * Select `No` when asked whether to enable authentication with Passport.
-* Select `No` when asked if you want to enable the explorer test interface.
-* Select `No` when asked if you want to enable dynamic logging.
+* Select `Yes` when asked if you want to enable the explorer test interface.
+* Press `ENTER` when asked for the key to enable dynamic logging.
 * Select `Yes` when asked whether to enable event publication.
 * Select `No` when asked whether to enable TLS security.
 


### PR DESCRIPTION
Two choices were wrong:
1. the explorer must be enabled to connect to "http://localhost:3000/explorer" so select "Yes" and not "No";
2. don't insert anything when asking for key but simply press ENTER; otherwise "No" is used as key.